### PR TITLE
Fix database connection to support both DATABASE_URL and NEON_DATABASE_URL

### DIFF
--- a/src/scoracle_data/pg_async.py
+++ b/src/scoracle_data/pg_async.py
@@ -39,10 +39,10 @@ class AsyncPostgresDB:
             min_pool_size: Minimum connections to keep in pool.
             max_pool_size: Maximum connections in pool.
         """
-        self.connection_string = connection_string or os.environ.get("DATABASE_URL")
+        self.connection_string = connection_string or os.environ.get("DATABASE_URL") or os.environ.get("NEON_DATABASE_URL")
         if not self.connection_string:
             raise ValueError(
-                "DATABASE_URL environment variable required or connection_string must be provided"
+                "DATABASE_URL or NEON_DATABASE_URL environment variable required or connection_string must be provided"
             )
 
         self._max_pool_size = max_pool_size or int(os.environ.get("DATABASE_POOL_SIZE", 10))

--- a/src/scoracle_data/pg_connection.py
+++ b/src/scoracle_data/pg_connection.py
@@ -38,10 +38,10 @@ class PostgresDB:
             min_pool_size: Minimum connections to keep in pool.
             max_pool_size: Maximum connections in pool. Defaults to DATABASE_POOL_SIZE env var or 10.
         """
-        self.connection_string = connection_string or os.environ.get("DATABASE_URL")
+        self.connection_string = connection_string or os.environ.get("DATABASE_URL") or os.environ.get("NEON_DATABASE_URL")
         if not self.connection_string:
             raise ValueError(
-                "DATABASE_URL environment variable required or connection_string must be provided"
+                "DATABASE_URL or NEON_DATABASE_URL environment variable required or connection_string must be provided"
             )
 
         self._max_pool_size = max_pool_size or int(os.environ.get("DATABASE_POOL_SIZE", 10))


### PR DESCRIPTION
- Updated pg_connection.py to check for both DATABASE_URL and NEON_DATABASE_URL
- Updated pg_async.py to check for both DATABASE_URL and NEON_DATABASE_URL
- This fixes 500 errors that occur when only NEON_DATABASE_URL is set
- Both files now match the config.py behavior which supports both variables