### PR TITLE
Fix first API call returning no data

### DIFF
--- a/src/scoracle_data/api/main.py
+++ b/src/scoracle_data/api/main.py
@@ -184,9 +184,12 @@ async def lifespan(app: FastAPI):
     try:
         from .dependencies import get_db
         db = get_db()
-        # Execute a simple query to establish connection(s)
+        # Explicitly open the pool to establish min_size connections
+        db.open()
+        logger.info(f"Database connection pool opened (min_size={db._min_pool_size}, max_size={db._max_pool_size})")
+        # Verify with a test query
         db.fetchone("SELECT 1")
-        logger.info("Database connection pool initialized")
+        logger.info("Database connection pool initialized and verified")
     except Exception as e:
         logger.error(f"Failed to initialize database: {e}")
         # Don't fail startup, let requests handle connection errors

--- a/src/scoracle_data/pg_connection.py
+++ b/src/scoracle_data/pg_connection.py
@@ -55,6 +55,16 @@ class PostgresDB:
             kwargs={"row_factory": dict_row},
         )
 
+    def open(self) -> None:
+        """
+        Explicitly open the connection pool.
+
+        This establishes the minimum number of connections immediately,
+        rather than waiting for the first request (lazy initialization).
+        Call this at application startup to ensure the pool is ready.
+        """
+        self._pool.open()
+
     @contextmanager
     def get_connection(self) -> Iterator[psycopg.Connection]:
         """Get a connection from the pool."""


### PR DESCRIPTION
… pool

Root cause: The synchronous ConnectionPool in PostgresDB was lazy and never explicitly opened, unlike the async version. This caused the first API request to time out or fail while connections were being established on-demand.

Changes:
- Add open() method to PostgresDB class that explicitly calls pool.open()
- Call open() during API startup in lifespan() before accepting requests
- Add improved logging to show pool configuration during startup

This matches the pattern used in AsyncPostgresDB and ensures all min_size connections are established during startup, not on first request.

Fixes: First API call returns nothing, subsequent calls work correctly