### PR TITLE
Disable LISTEN/NOTIFY and fix PostgREST logging for Railway

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       PGRST_DB_SCHEMAS: api
       PGRST_DB_ANON_ROLE: web_anon
       PGRST_OPENAPI_MODE: follow-privileges
+      PGRST_DB_CHANNEL_ENABLED: "false"
 
   api:
     build: go/

--- a/postgrest/Dockerfile
+++ b/postgrest/Dockerfile
@@ -9,6 +9,16 @@ FROM alpine:3.21
 RUN apk add --no-cache libpq \
     && adduser -D -u 1000 -h /tmp postgrest
 COPY --from=src /bin/postgrest /bin/postgrest
+
+# Disable the LISTEN/NOTIFY channel.  Railway's Postgres proxy kills idle
+# connections every ~5-10 min, which causes a noisy reconnect loop.
+# Schema reloads happen on redeploy anyway.
+ENV PGRST_DB_CHANNEL_ENABLED=false
+
 USER postgrest
 EXPOSE 3000
-CMD ["postgrest"]
+
+# PostgREST writes *all* log output to stderr.  Railway classifies stderr
+# as [err], which makes GitHub mark every deployment as "failed" even when
+# the service is healthy.  Redirect stderr → stdout so logs appear as [inf].
+CMD ["sh", "-c", "exec postgrest 2>&1"]


### PR DESCRIPTION
## Summary
This PR addresses two issues with PostgREST deployment on Railway:
1. Disables the LISTEN/NOTIFY channel to prevent noisy reconnect loops caused by Railway's Postgres proxy killing idle connections
2. Redirects stderr to stdout so PostgREST logs are properly classified as informational rather than errors

## Key Changes
- **Disable LISTEN/NOTIFY**: Set `PGRST_DB_CHANNEL_ENABLED=false` in both the Dockerfile and docker-compose.yml to prevent automatic schema reloads via database notifications (schema reloads still occur on redeploy)
- **Fix log output classification**: Modified the PostgREST startup command to redirect stderr to stdout (`exec postgrest 2>&1`), preventing Railway from incorrectly marking deployments as failed due to stderr output
- **Updated docker-compose.yml**: Added the `PGRST_DB_CHANNEL_ENABLED` environment variable to the PostgREST service configuration for consistency

## Implementation Details
- The Dockerfile now uses `sh -c` to execute the redirect command, ensuring stderr is properly piped to stdout before PostgREST starts
- Both configuration files are updated to maintain consistency across local development and production deployments

https://claude.ai/code/session_01Ugyzf2dMh9fatvZQnDVawJ