### PR TITLE
Make PostgREST server port configurable via PORT environment variable

### DIFF
--- a/postgrest/Dockerfile
+++ b/postgrest/Dockerfile
@@ -21,4 +21,4 @@ EXPOSE 3000
 # PostgREST writes *all* log output to stderr.  Railway classifies stderr
 # as [err], which makes GitHub mark every deployment as "failed" even when
 # the service is healthy.  Redirect stderr → stdout so logs appear as [inf].
-CMD ["sh", "-c", "exec postgrest 2>&1"]
+CMD ["sh", "-c", "PGRST_SERVER_PORT=${PORT:-3000} exec postgrest 2>&1"]


### PR DESCRIPTION
## Summary
Updated the PostgREST Docker container startup command to respect a `PORT` environment variable, defaulting to port 3000 if not specified.

## Key Changes
- Modified the CMD instruction in the Dockerfile to set the `PGRST_SERVER_PORT` environment variable before starting PostgREST
- The port is now configurable via the `PORT` environment variable, with a fallback to the default port 3000
- This allows the container to be deployed on platforms (like Railway) that dynamically assign ports via environment variables

## Implementation Details
- The change uses shell parameter expansion (`${PORT:-3000}`) to provide a default value
- The `PGRST_SERVER_PORT` variable is set in the same command that starts PostgREST, ensuring it takes effect immediately
- Maintains backward compatibility by defaulting to port 3000 when `PORT` is not set
- Preserves the existing stderr-to-stdout redirection for proper log classification

https://claude.ai/code/session_01BXYceQdf8jLKmivqiK3M5k