### PR TITLE
fix: unify DB URL resolution between Go API and PostgREST

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,11 +101,17 @@ RATE_LIMIT_WINDOW=60
 # =============================================================================
 # PostgREST Configuration
 # =============================================================================
-# PostgREST env vars — used by docker-compose.yml to configure the PostgREST
-# container locally. In Railway, these are set on the PostgREST service directly.
+# Both the Go API and PostgREST resolve the DB connection string using the
+# same priority chain:
 #
-# PGRST_DB_URI is mapped from DATABASE_URL in docker-compose.yml, so no need
-# to duplicate it here. Add PGRST_JWT_SECRET if you use JWT auth locally:
+#   NEON_DATABASE_URL_V2 > DATABASE_URL > NEON_DATABASE_URL
+#
+# Set the connection string in ANY ONE of those variables and both services
+# will find it. You do NOT need to set PGRST_DB_URI separately — the
+# PostgREST entrypoint script (postgrest/entrypoint.sh) resolves it
+# automatically. If you do set PGRST_DB_URI explicitly, it takes top priority.
+#
+# Add PGRST_JWT_SECRET if you use JWT auth locally:
 # PGRST_JWT_SECRET=your_jwt_secret_here
 #
 # The Go API references POSTGREST_URL for the multi-spec Swagger UI.
@@ -119,8 +125,8 @@ POSTGREST_URL=http://localhost:3000
 # Start both services:  docker compose up --build
 # Stop:                 docker compose down
 #
-# Compose reads this .env file automatically. It maps DATABASE_URL to
-# PGRST_DB_URI and overrides POSTGREST_URL for inter-container networking.
-# No additional configuration needed beyond what's already in this file.
+# Compose reads this .env file automatically and forwards the DB URL variables
+# to the PostgREST container, where entrypoint.sh resolves them using the same
+# priority chain as the Go API. No additional configuration needed.
 
 # Current seasons are defined in code (core/types.py SPORT_REGISTRY).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,13 @@ services:
       - "3000:3000"
     env_file: .env
     environment:
-      PGRST_DB_URI: ${DATABASE_URL}
+      # Mirror the Go API's fallback chain (config.go):
+      # NEON_DATABASE_URL_V2 > DATABASE_URL > NEON_DATABASE_URL
+      # The entrypoint.sh handles this automatically, so we just forward
+      # whichever variables are set — no need to pick one here.
+      NEON_DATABASE_URL_V2: ${NEON_DATABASE_URL_V2:-}
+      DATABASE_URL: ${DATABASE_URL:-}
+      NEON_DATABASE_URL: ${NEON_DATABASE_URL:-}
 
   api:
     build: go/

--- a/postgrest/Dockerfile
+++ b/postgrest/Dockerfile
@@ -7,6 +7,7 @@ FROM alpine:3.21
 RUN apk add --no-cache libpq \
     && adduser -D -u 1000 -h /tmp postgrest
 COPY --from=src /bin/postgrest /bin/postgrest
+COPY entrypoint.sh /bin/entrypoint.sh
 
 ENV PGRST_DB_CHANNEL_ENABLED=false \
     PGRST_DB_SCHEMAS=api \
@@ -17,4 +18,4 @@ ENV PGRST_DB_CHANNEL_ENABLED=false \
 USER postgrest
 EXPOSE 3000
 
-ENTRYPOINT ["/bin/postgrest"]
+ENTRYPOINT ["/bin/entrypoint.sh"]

--- a/postgrest/entrypoint.sh
+++ b/postgrest/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# PostgREST entrypoint — resolves the DB connection string using the same
+# priority chain as the Go API (see go/internal/config/config.go):
+#
+#   PGRST_DB_URI (explicit) > NEON_DATABASE_URL_V2 > DATABASE_URL > NEON_DATABASE_URL
+#
+# This ensures both services always connect to the same database regardless of
+# which env var the operator populates. Change the connection string in any one
+# of these variables and both services pick it up.
+
+set -e
+
+if [ -z "$PGRST_DB_URI" ]; then
+    PGRST_DB_URI="${NEON_DATABASE_URL_V2:-${DATABASE_URL:-${NEON_DATABASE_URL:-}}}"
+    export PGRST_DB_URI
+fi
+
+if [ -z "$PGRST_DB_URI" ]; then
+    echo "FATAL: no database URL found." >&2
+    echo "Set one of: PGRST_DB_URI, NEON_DATABASE_URL_V2, DATABASE_URL, NEON_DATABASE_URL" >&2
+    exit 1
+fi
+
+exec /bin/postgrest "$@"

--- a/progress_docs/2026-03-13_fix-postgrest-db-url-resolution.md
+++ b/progress_docs/2026-03-13_fix-postgrest-db-url-resolution.md
@@ -1,0 +1,25 @@
+# Session: Fix PostgREST DB URL Resolution
+**Date:** 2026-03-13
+
+## Goals
+- Diagnose why PostgREST health checks fail after changing the database connection string
+- Implement a clean, long-term fix so future connection string changes work for both services
+
+## Decisions Made
+| Decision | Rationale |
+|----------|-----------|
+| Add entrypoint.sh with same fallback chain as Go API | Single source of truth for DB URL resolution — both services now follow the same priority: `NEON_DATABASE_URL_V2` > `DATABASE_URL` > `NEON_DATABASE_URL` |
+| Forward all three env vars in docker-compose instead of mapping one | Lets entrypoint.sh handle resolution consistently across local dev and Railway |
+| Keep `PGRST_DB_URI` as an explicit override | If someone sets it directly (e.g., in Railway dashboard), it takes top priority — no surprise behavior |
+
+## Root Cause
+The Go API (`config.go`) resolves the DB URL through a 3-level fallback chain (`NEON_DATABASE_URL_V2` > `DATABASE_URL` > `NEON_DATABASE_URL`), but `docker-compose.yml` hardcoded PostgREST's `PGRST_DB_URI` to only `${DATABASE_URL}`. When the connection string lived in a higher-priority variable (e.g., `NEON_DATABASE_URL_V2`), the Go API connected fine while PostgREST received an empty/stale URL and failed permanently.
+
+## Accomplishments
+### Created
+- `postgrest/entrypoint.sh` — shell wrapper that resolves the DB URL using the same priority chain as the Go API before exec-ing PostgREST
+
+### Updated
+- `postgrest/Dockerfile` — switched `ENTRYPOINT` from `/bin/postgrest` to `/bin/entrypoint.sh`
+- `docker-compose.yml` — forwards all three DB URL env vars instead of mapping only `DATABASE_URL`
+- `.env.example` — updated PostgREST and Docker Compose sections to document the shared resolution chain


### PR DESCRIPTION
PostgREST health checks failed after connection string changes because
docker-compose hardcoded PGRST_DB_URI to ${DATABASE_URL}, while the Go
API resolves through a 3-level fallback chain (NEON_DATABASE_URL_V2 >
DATABASE_URL > NEON_DATABASE_URL). When the connection string lived in a
higher-priority variable, PostgREST received an empty/stale URL.

Add postgrest/entrypoint.sh that resolves the DB URL using the same
priority chain as the Go API. Both services now find the connection
string regardless of which env var it's set in.

https://claude.ai/code/session_01VMFAMHVruv2rMD3hTn7vUH